### PR TITLE
[Client] 방 생성 페이지 레이아웃 

### DIFF
--- a/client/hooks/useInput.js
+++ b/client/hooks/useInput.js
@@ -1,0 +1,10 @@
+import { useState, useCallback } from 'react';
+
+const useInput = () => {
+  const [value, setValue] = useState('');
+  const handler = useCallback(({ target }) => setValue(target.value), []);
+
+  return [value, setValue, handler];
+};
+
+export default useInput;

--- a/client/pages/CreateRoom.js
+++ b/client/pages/CreateRoom.js
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import styled from '@emotion/styled';
+
+import useInput from '@hooks/useInput';
+
+const CreateRoom = () => {
+  const [nickname, setNickname, handler] = useInput();
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    console.log('form submiitted');
+    console.log(nickname);
+  };
+
+  return (
+    <Wrapper onSubmit={handleSubmit}>
+      <input value={nickname} onChange={handler} placeholder="닉네임을 입력해 주세요." />
+      <button>방 만들기</button>
+    </Wrapper>
+  );
+};
+
+export default CreateRoom;
+
+const Wrapper = styled.form`
+  height: 100vh;
+  border: 1px solid green;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  & > input {
+    width: 25%;
+    height: 3rem;
+    padding-left: 10px;
+    font-size: 1.2rem;
+  }
+  & > button {
+    width: 10%;
+    min-width: 200px;
+    margin-top: 3rem;
+    padding: 0.5rem 1rem;
+    border: none;
+    font-size: 1.2rem;
+    &:hover {
+      cursor: pointer;
+    }
+  }
+`;


### PR DESCRIPTION
## 개요
게임 생성 페이지 간단한 레이아웃 작업 및 사용자 입력을 처리하는 custom hook 작성

## 작업사항
- 진행중인 화면의 wireframe
<img src="https://user-images.githubusercontent.com/38288479/138586017-767ff064-cb88-4c95-a2e9-2952bd69c1f2.png" width="500" />

- 게임 생성 페이지에 필요한 닉네임 입력 받기, 버튼 UI 추가
- 닉네임과 같은 사용자 입력 컴포넌트는 custom hook 적용과 더불어 별도의 컴포넌트로 분리 예정
